### PR TITLE
Change DOI format to match new Crossref guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ of functions you can select to load the more detailed help.
 
 ## References
 #### NetEMD
-Anatol E. Wegner, Luis Ospina-Forero, Robert E. Gaunt, Charlotte M. Deane, Gesine Reinert; Identifying networks with common organizational principles. ArXiv pre-print. [arXiv:1704.00387](https://arxiv.org/abs/1704.00387)
+Anatol E. Wegner, Luis Ospina-Forero, Robert E. Gaunt, Charlotte M. Deane, Gesine Reinert; Identifying networks with common organizational principles. [arXiv:1704.00387](https://arxiv.org/abs/1704.00387) (Open Access pre-print)
 
 #### NetDis
-Waqar Ali, Tiago Rito, Gesine Reinert, Fengzhu Sun, Charlotte M. Deane; Alignment-free protein interaction network comparison. Bioinformatics 2014; 30 (17): i430-i437. [doi:10.1093/bioinformatics/btu447](https://dx.doi.org/10.1093/bioinformatics/btu447) (Open Access)
+Waqar Ali, Tiago Rito, Gesine Reinert, Fengzhu Sun, Charlotte M. Deane; Alignment-free protein interaction network comparison. Bioinformatics 2014; 30 (17): i430-i437. https://doi.org/10.1093/bioinformatics/btu447 (Open Access)


### PR DESCRIPTION
The "doi:<doi-reference>" format had been deprecated. DOIs should now be displayed as full https url in the form "https://doi.org/<doi-reference>". See https://www.crossref.org/display-guidelines/