### PR TITLE
Fix test that broke with update to igraph package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,8 @@ Imports:
     orca,
     purrr,
     lpSolve,
-    plyr
+    plyr,
+    dplyr
 Suggests:
     testthat,
     knitr,

--- a/R/dhist.R
+++ b/R/dhist.R
@@ -540,5 +540,5 @@ harmonise_dhist_locations <- function(dhist1, dhist2) {
 #' @param input Arbitrary object
 #' @return TRUE if input is a 1D numeric vector. FALSE otherwise.
 is_numeric_vector_1d <- function(input) {
-  return(purrr::is_numeric(input) && purrr::is_null(dim(input)))
+  return(is.numeric(input) && purrr::is_null(dim(input)))
 }

--- a/R/measures_net_emd.R
+++ b/R/measures_net_emd.R
@@ -46,7 +46,7 @@ net_emds_for_all_graphs <- function(
   out <- purrr::simplify(parallel::mcmapply(function(index_a, index_b) {net_emd(
     gdds[[index_a]], gdds[[index_b]], method = method, return_details = return_details,
     smoothing_window_width = smoothing_window_width)
-    }, comp_spec$index_a, comp_spec$index_b, SIMPLIFY = FALSE))
+    }, comp_spec$index_a, comp_spec$index_b, SIMPLIFY = FALSE, mc.cores = mc.cores))
   if(return_details) {
     net_emds <- purrr::simplify(purrr::map(out, ~.$net_emd))
     min_emds <- matrix(purrr::simplify(purrr::map(out, ~.$min_emds)), ncol = num_features, byrow = TRUE)

--- a/tests/testthat/test_orca_interface.R
+++ b/tests/testthat/test_orca_interface.R
@@ -745,20 +745,22 @@ test_that("make_named_ego_graph labels each ego-network with the correct node na
   # We compare edgelists as igraphs do not implement comparison
   order <- 1
   expected_ego_elists_o1 <- list(
-    n1 = expected_ego_elist_n1_o1,
-    n2 = expected_ego_elist_n2_o1,
-    n3 = expected_ego_elist_n3_o1,
-    n4 = expected_ego_elist_n4_o1,
-    n5 = expected_ego_elist_n5_o1,
-    n6 = expected_ego_elist_n6_o1,
-    n7 = expected_ego_elist_n7_o1,
-    n8 = expected_ego_elist_n8_o1,
-    n9 = expected_ego_elist_n9_o1,
-    n10 = expected_ego_elist_n10_o1
+    n1 =  dplyr::arrange(data.frame(expected_ego_elist_n1_o1), X1, X2),
+    n2 =  dplyr::arrange(data.frame(expected_ego_elist_n2_o1), X1, X2),
+    n3 =  dplyr::arrange(data.frame(expected_ego_elist_n3_o1), X1, X2),
+    n4 =  dplyr::arrange(data.frame(expected_ego_elist_n4_o1), X1, X2),
+    n5 =  dplyr::arrange(data.frame(expected_ego_elist_n5_o1), X1, X2),
+    n6 =  dplyr::arrange(data.frame(expected_ego_elist_n6_o1), X1, X2),
+    n7 =  dplyr::arrange(data.frame(expected_ego_elist_n7_o1), X1, X2),
+    n8 =  dplyr::arrange(data.frame(expected_ego_elist_n8_o1), X1, X2),
+    n9 =  dplyr::arrange(data.frame(expected_ego_elist_n9_o1), X1, X2),
+    n10 = dplyr::arrange(data.frame(expected_ego_elist_n10_o1), X1, X2)
   )
   # Generate actual ego-networks and convert to edge lists for comparison
   actual_ego_elists_o1 <- 
-    purrr::map(make_named_ego_graph(graph, order), igraph::as_edgelist)
+    purrr::map(make_named_ego_graph(graph, order), function(g) {
+      dplyr::arrange(data.frame(igraph::as_edgelist(g)), X1, X2)
+      })
   expect_equal(actual_ego_elists_o1, expected_ego_elists_o1)
 })
 


### PR DESCRIPTION
- Fixes issue #65 (previously passing CI test failed on Travis CI).
  - Issue was change in ordering of edge rows returned by `igraph::as_edgelist()` from v1.0.1 to v1.1.1
- Also updates `net_emd_for_all_graphs` to pass `mc.cores` parameter to `mcapply`.