### PR TITLE
Simplify graph when generating GDD

### DIFF
--- a/R/orca_interface.R
+++ b/R/orca_interface.R
@@ -208,6 +208,7 @@ orca_counts_to_graphlet_orbit_degree_distribution <- function(orca_counts) {
 #' @export
 gdd <- function(graph, feature_type = 'orbit', max_graphlet_size = 4, 
                 ego_neighbourhood_size = 0){
+  graph <- simplify_graph(graph)
   if(ego_neighbourhood_size > 0) {
     if(feature_type != 'graphlet') {
       stop("Feature type not supported for ego-networks")


### PR DESCRIPTION
Need to add a simplify_graph call to the gdd code, as if we are working from igraphs, it is possible they will have disconnected nodes.

