### PR TITLE
added a line to remove the mean before computing the variance

### DIFF
--- a/R/measures_net_emd.R
+++ b/R/measures_net_emd.R
@@ -149,12 +149,20 @@ net_emd_single_pair <- function(dhist1, dhist2, method = "optimise",
     dhist2 <- as_smoothed_dhist(dhist2, smoothing_window_width)
   }
   ## add mean centering
+
+  ### Stores means to fix offset later
+  mean1 <- dhist_mean_location(dhist1)
+  mean2 <- dhist_mean_location(dhist2)
+  ### Mean centre
   dhist1<-mean_centre_dhist(dhist1)
   dhist2<-mean_centre_dhist(dhist2)
+
   # Normalise histogram to unit mass and unit variance
   dhist1_norm <- normalise_dhist_variance(normalise_dhist_mass(dhist1))
   dhist2_norm <- normalise_dhist_variance(normalise_dhist_mass(dhist2))
   
-  return(min_emd(dhist1_norm, dhist2_norm, method = method))
+  result <- min_emd(dhist1_norm, dhist2_norm, method = method)
+  result$min_offset <- result$min_offset +mean2-mean1
+  return(result)
 }
 

--- a/R/measures_net_emd.R
+++ b/R/measures_net_emd.R
@@ -148,7 +148,9 @@ net_emd_single_pair <- function(dhist1, dhist2, method = "optimise",
     dhist1 <- as_smoothed_dhist(dhist1, smoothing_window_width)
     dhist2 <- as_smoothed_dhist(dhist2, smoothing_window_width)
   }
-  
+  ## add mean centering
+  dhist1<-mean_centre_dhist(dhist1)
+  dhist2<-mean_centre_dhist(dhist2)
   # Normalise histogram to unit mass and unit variance
   dhist1_norm <- normalise_dhist_variance(normalise_dhist_mass(dhist1))
   dhist2_norm <- normalise_dhist_variance(normalise_dhist_mass(dhist2))


### PR DESCRIPTION
Without doing so, for networks with large counts for certain features the numerical precision for large numbers kills accuracy resulting in the differences between the python code and the R code.

This is a fix for issue #82 