### PR TITLE
Get C++11 working with default Travis gcc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,6 @@ r_packages:
 os:
 - linux
 
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - gcc-4.9
-      - g++-4.9
-env:
-  - CC=gcc-4.9 CXX=g++-4.9
-
 after_success:
 - Rscript -e 'library(covr); codecov()'
 


### PR DESCRIPTION
Travis default compiler is gcc-4.8.2, which should have full c++11 support, with the exception of `<regex>` (gcc self-declared in 4.8.1, but `<regex>` support didn't come until 4.9.